### PR TITLE
Feature/144 shell read command refactor

### DIFF
--- a/common/src/main/java/com/samsung/file/FileManager.java
+++ b/common/src/main/java/com/samsung/file/FileManager.java
@@ -34,7 +34,6 @@ public class FileManager {
             byte[] buf = new byte[10];
             file.read(buf);
             result = new String(buf);
-            file.close();
         } catch (IOException e) {
 
         }
@@ -68,7 +67,6 @@ public class FileManager {
             RandomAccessFile file = new RandomAccessFile(SSD_NAND_FILE_NAME, "rw");
             file.seek(index * OFFSET);
             file.writeBytes(value);
-            file.close();
         } catch (IOException e) {
 
         }

--- a/common/src/main/java/com/samsung/file/FileManager.java
+++ b/common/src/main/java/com/samsung/file/FileManager.java
@@ -34,6 +34,7 @@ public class FileManager {
             byte[] buf = new byte[10];
             file.read(buf);
             result = new String(buf);
+            file.close();
         } catch (IOException e) {
 
         }
@@ -55,6 +56,7 @@ public class FileManager {
             RandomAccessFile file = new RandomAccessFile(SSD_NAND_FILE_NAME, "rw");
             file.seek(index * OFFSET);
             file.writeBytes(value);
+            file.close();
         } catch (IOException e) {
 
         }

--- a/common/src/main/java/com/samsung/file/FileManager.java
+++ b/common/src/main/java/com/samsung/file/FileManager.java
@@ -41,6 +41,18 @@ public class FileManager {
         return result;
     }
 
+    public String getResultFromOutputFile() {
+        String result = null;
+
+        try{
+            result = Files.readString(Path.of(SSD_OUTPUT_FILE_NAME));
+        }catch(IOException e) {
+
+        }
+
+        return result;
+    }
+
     public List<String> getAllValuesFromFile(){
         List<String> result = null;
         try {

--- a/shell/src/main/java/com/samsung/command/testshell/TestShellManager.java
+++ b/shell/src/main/java/com/samsung/command/testshell/TestShellManager.java
@@ -70,6 +70,7 @@ public class TestShellManager {
 
     public void fullread() {
         String head = "[Full Read] LBA";
+
         for(int i = 0; i < 100; i++) {
             jarExecutor.executeRead(i);
             String value = fileManager.getResultFromOutputFile();

--- a/shell/src/main/java/com/samsung/command/testshell/TestShellManager.java
+++ b/shell/src/main/java/com/samsung/command/testshell/TestShellManager.java
@@ -3,7 +3,6 @@ package com.samsung.command.testshell;
 import com.samsung.file.FileManager;
 import com.samsung.file.JarExecutor;
 import lombok.extern.slf4j.Slf4j;
-import java.util.List;
 
 @Slf4j
 public class TestShellManager {
@@ -29,7 +28,9 @@ public class TestShellManager {
     public void read(int index) {
         String head = "[Read] LBA";
         String location = String.format("%02d", index);
-        String value = fileManager.getValueFromFile(index);
+
+        jarExecutor.executeRead(index);
+        String value = fileManager.getResultFromOutputFile();
 
         System.out.println(head + " " + location + " " + value);
     }
@@ -69,12 +70,11 @@ public class TestShellManager {
 
     public void fullread() {
         String head = "[Full Read] LBA";
-        List<String> values = fileManager.getAllValuesFromFile();
-        int index = 0;
-        for(String value : values){
-            if(index == 100) break;
-            String location = String.format("%02d", index++);
-            System.out.println(head + " " + location + " " + value);
+        for(int i = 0; i < 100; i++) {
+            jarExecutor.executeRead(i);
+            String value = fileManager.getResultFromOutputFile();
+
+            System.out.println(head + " " + i + " " + value);
         }
     }
 

--- a/shell/src/main/java/com/samsung/file/JarExecutor.java
+++ b/shell/src/main/java/com/samsung/file/JarExecutor.java
@@ -8,7 +8,11 @@ import java.util.List;
 
 @Slf4j
 public class JarExecutor {
-    private static final int DEFAULT_WAIT_MILLIS = 1000;
+    private static final int DEFAULT_WAIT_MILLIS = 100;
+
+    public void executeRead(Integer lba) {
+        executeCommand("R", String.valueOf(lba));
+    }
 
     public void executeWrite(Integer lba, String value) {
         executeCommand("W", lba.toString(), value);

--- a/shell/src/main/java/com/samsung/file/JarExecutor.java
+++ b/shell/src/main/java/com/samsung/file/JarExecutor.java
@@ -37,8 +37,8 @@ public class JarExecutor {
             pb.inheritIO();
             pb.start();
 
-            Thread.sleep(DEFAULT_WAIT_MILLIS);
-        } catch (IOException | InterruptedException e) {
+            // Thread.sleep(DEFAULT_WAIT_MILLIS);
+        } catch (IOException e) {
             e.printStackTrace();
         }
     }

--- a/shell/src/main/java/com/samsung/file/JarExecutor.java
+++ b/shell/src/main/java/com/samsung/file/JarExecutor.java
@@ -41,8 +41,8 @@ public class JarExecutor {
             pb.inheritIO();
             pb.start();
 
-            // Thread.sleep(DEFAULT_WAIT_MILLIS);
-        } catch (IOException e) {
+            Thread.sleep(DEFAULT_WAIT_MILLIS);
+        } catch (IOException | InterruptedException e) {
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
# Shell Read 변경
Shell Read 시 ssd-all.jar 파일에 Read 명령어 수행하지 않고 fileManager로 txt 파일에 직접 접근하던 방식을
ssd-all.jar 파일에서 Read 명령어 실행 후 output 파일을 읽어오는 방식으로 변경

FileManager에 Output 파일 결과 읽어오는 함수 추가
fullread 시 read 명령 1회 실행 -> output 파일 읽기 100번 반복으로 변경

jarExecutor 에서 File I/O 후 대기 시간 100ms로 변경(10ms 이하로 하면 Shell에서 1_, 2_, 3_ 명령어 실행 시 잦은 오류 발생)