### PR TITLE
Feature/162 console clear

### DIFF
--- a/common/src/main/java/com/samsung/file/FileManager.java
+++ b/common/src/main/java/com/samsung/file/FileManager.java
@@ -44,30 +44,16 @@ public class FileManager{
         return result;
     }
 
-    public String getResultFromOutputFile(Long commandRequestTime) {
+    public String getResultFromOutputFile() {
         String result = null;
 
-        Long currentTime = System.currentTimeMillis();
-
         try{
-            while(System.currentTimeMillis() <= currentTime + 1000 && !isReadable(commandRequestTime)) {
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
             result = Files.readString(Path.of(SSD_OUTPUT_FILE_NAME));
         } catch (IOException e) {
 
         }
 
         return result;
-    }
-
-    private boolean isReadable(Long currentTime) throws IOException {
-        return Files.exists(Path.of(SSD_OUTPUT_FILE_NAME)) && Files.getLastModifiedTime(Path.of(SSD_OUTPUT_FILE_NAME)).toMillis() >= currentTime;
     }
 
     public void writeFile(int index, String value) {

--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -1,4 +1,6 @@
 <configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
     <property name="LOG_DIR" value="${user.dir}/logs"/>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">

--- a/common/src/main/resources/logback.xml
+++ b/common/src/main/resources/logback.xml
@@ -1,11 +1,12 @@
 <configuration>
+    <root level="OFF" />
+
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
     <property name="LOG_DIR" value="${user.dir}/logs"/>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_DIR}/latest.log</file>
-
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>${LOG_DIR}/until_%d{yyyyMMdd_HHmm}.%i.log</fileNamePattern>
 
@@ -26,4 +27,5 @@
         <appender-ref ref="FILE"/>
         <appender-ref ref="COMPRESSOR"/>
     </root>
+
 </configuration>

--- a/shell/src/main/java/com/samsung/command/testshell/TestShellManager.java
+++ b/shell/src/main/java/com/samsung/command/testshell/TestShellManager.java
@@ -31,7 +31,7 @@ public class TestShellManager {
 
         Long requestCommandTime = System.currentTimeMillis();
         jarExecutor.executeRead(index);
-        String value = fileManager.getResultFromOutputFile(requestCommandTime);
+        String value = fileManager.getResultFromOutputFile();
 
         System.out.println(head + " " + location + " " + value);
     }
@@ -75,7 +75,7 @@ public class TestShellManager {
         for(int i = 0; i < 100; i++) {
             Long requestCommandTime = System.currentTimeMillis();
             jarExecutor.executeRead(i);
-            String value = fileManager.getResultFromOutputFile(requestCommandTime);
+            String value = fileManager.getResultFromOutputFile();
 
             System.out.println(head + " " + String.format("%02d", i) + " " + value);
         }

--- a/shell/src/main/java/com/samsung/file/JarExecutor.java
+++ b/shell/src/main/java/com/samsung/file/JarExecutor.java
@@ -9,8 +9,6 @@ import java.util.concurrent.TimeUnit;
 
 @Slf4j
 public class JarExecutor {
-    private static final int DEFAULT_WAIT_MILLIS = 500;
-
     public void executeRead(Integer lba) {
         executeCommand("R", String.valueOf(lba));
     }
@@ -44,7 +42,6 @@ public class JarExecutor {
 
             pb.start().waitFor(1000L, TimeUnit.MILLISECONDS);
 
-            // Thread.sleep(DEFAULT_WAIT_MILLIS);
         } catch (IOException | InterruptedException e) {
             e.printStackTrace();
         }

--- a/shell/src/main/java/com/samsung/file/JarExecutor.java
+++ b/shell/src/main/java/com/samsung/file/JarExecutor.java
@@ -49,6 +49,6 @@ public class JarExecutor {
 
     private String getSsdJarPath() {
         String projectRoot = System.getProperty("user.dir");
-        return projectRoot + "\\ssd-all.jar";
+        return projectRoot + "\\ssd.jar";
     }
 }

--- a/shell/src/main/java/com/samsung/file/JarExecutor.java
+++ b/shell/src/main/java/com/samsung/file/JarExecutor.java
@@ -38,10 +38,7 @@ public class JarExecutor {
             System.out.println("Executing command: " + String.join(" ", command));
 
             pb.inheritIO();
-            pb.start();
-
-            pb.start().waitFor(1000L, TimeUnit.MILLISECONDS);
-
+            pb.start().waitFor(5000L, TimeUnit.MILLISECONDS);
         } catch (IOException | InterruptedException e) {
             e.printStackTrace();
         }

--- a/shell/src/main/java/com/samsung/file/JarExecutor.java
+++ b/shell/src/main/java/com/samsung/file/JarExecutor.java
@@ -5,10 +5,11 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 public class JarExecutor {
-    private static final int DEFAULT_WAIT_MILLIS = 100;
+    private static final int DEFAULT_WAIT_MILLIS = 500;
 
     public void executeRead(Integer lba) {
         executeCommand("R", String.valueOf(lba));
@@ -41,7 +42,9 @@ public class JarExecutor {
             pb.inheritIO();
             pb.start();
 
-            Thread.sleep(DEFAULT_WAIT_MILLIS);
+            pb.start().waitFor(1000L, TimeUnit.MILLISECONDS);
+
+            // Thread.sleep(DEFAULT_WAIT_MILLIS);
         } catch (IOException | InterruptedException e) {
             e.printStackTrace();
         }

--- a/shell/src/test/java/com/samsung/command/testshell/TestShellManagerTest.java
+++ b/shell/src/test/java/com/samsung/command/testshell/TestShellManagerTest.java
@@ -45,7 +45,7 @@ class TestShellManagerTest {
     void testShellReadExecute() {
         testShellManager.read(INDEX);
 
-        verify(fileManager, times(1)).getResultFromOutputFile(anyLong());
+        verify(fileManager, times(1)).getResultFromOutputFile();
     }
 
     @Test
@@ -54,7 +54,7 @@ class TestShellManagerTest {
         int index = INDEX;
         String value = "0xFFFFFFFF";
         String expected = "[Read] LBA 03 "+ value;
-        when(fileManager.getResultFromOutputFile(anyLong())).thenReturn(value);
+        when(fileManager.getResultFromOutputFile()).thenReturn(value);
 
         testShellManager.read(index);
 
@@ -118,13 +118,13 @@ class TestShellManagerTest {
             fakeData.add("0x00000000");
         }
 
-        when(fileManager.getResultFromOutputFile(anyLong())).thenReturn(fakeData.get(0))
+        when(fileManager.getResultFromOutputFile()).thenReturn(fakeData.get(0))
                 .thenReturn(fakeData.get(1))
                 .thenReturn(fakeData.get(2));
 
         testShellManager.fullread();
 
-        verify(fileManager, times(100)).getResultFromOutputFile(anyLong());
+        verify(fileManager, times(100)).getResultFromOutputFile();
 
         String[] outputLines = outContent.toString().trim().split("\n");
         assertThat(outputLines).hasSize(100);


### PR DESCRIPTION
# 수정사항
- 콘솔창에 로그 출력 방지
- ssd.jar 명령어 실행 후 Thread.sleep 하는 방식에서 명령어 끝날 때까지 대기하는 방식으로 변경
- Shell에서 ssd-all.jar -> ssd.jar 실행으로 변경
- Shell에서 Read 명령어 실행 할 때, ssd_output.txt 파일 읽는 방식 변경

- 
![image](https://github.com/user-attachments/assets/e5af173e-0403-4a13-ab01-011e5182f2f5)
