### PR TITLE
[refactor] CommandInvoker 리팩토링 (CommandRegistry 클래스로 책임 분리)

### DIFF
--- a/shell/src/main/java/com/samsung/command/CommandInvoker.java
+++ b/shell/src/main/java/com/samsung/command/CommandInvoker.java
@@ -1,71 +1,26 @@
 package com.samsung.command;
 
-import com.samsung.file.FileManager;
-import com.samsung.command.testscript.*;
-import com.samsung.command.testshell.*;
-import com.samsung.file.JarExecutor;
-
-import java.util.Map;
-
 public class CommandInvoker {
 
-    private final Map<String, Command> commandMap;
+    private static final int COMMAND_NAME_INDEX = 0;
 
-    public CommandInvoker(Map<String, Command> commandMap) {
-        this.commandMap = commandMap;
-        initShellCommand();
-        initScriptCommand();
+    private final CommandRegistry registry;
+
+    public CommandInvoker(CommandRegistry registry) {
+        this.registry = registry;
     }
 
     public void execute(String[] cmdArgs) {
-        Command command = getCommand(cmdArgs[0]);
+        Command command = registry.getCommand(cmdArgs[COMMAND_NAME_INDEX]);
+        validateCommandNotNull(command);
+
         command.execute(cmdArgs);
     }
 
-    private Command getCommand(String commandName) {
-        Command command = commandMap.get(commandName);
-
+    private void validateCommandNotNull(Command command) {
         if (command == null) {
             throw new RuntimeException("INVALID COMMAND");
         }
-
-        return command;
     }
 
-    private void initShellCommand() {
-        TestShellManager testShellManager = new TestShellManager(new JarExecutor(), FileManager.getInstance());
-        register("write", new WriteCommand(testShellManager));
-        register("read", new ReadCommand(testShellManager));
-        register("erase", new EraseCommand(testShellManager));
-        register("erase_range", new EraseRangeCommand(testShellManager));
-        register("exit", new ExitCommand(testShellManager));
-        register("help", new HelpCommand(testShellManager));
-        register("fullwrite", new FullWriteCommand(testShellManager));
-        register("fullread", new FullReadCommand(testShellManager));
-        register("flush", new FlushCommand(testShellManager));
-    }
-
-    private void register(String commandName, Command command) {
-        commandMap.put(commandName, command);
-    }
-
-    private void initScriptCommand() {
-        ScriptManager scriptManager = new ScriptManager(FileManager.getInstance(), new JarExecutor(), RandomHex.getInstance());
-
-        String[] script1CommandNames = {"1_FullWriteAndReadCompare", "1_"};
-        String[] script2CommandNames = {"2_PartialLBAWrite", "2_"};
-        String[] script3CommandNames = {"3_WriteReadAging", "3_"};
-        String[] script4CommandNames = {"4_EraseAndWriteAging", "4_"};
-
-        register(script1CommandNames, new TestScript1Command(scriptManager));
-        register(script2CommandNames, new TestScript2Command(scriptManager));
-        register(script3CommandNames, new TestScript3Command(scriptManager));
-        register(script4CommandNames, new TestScript4Command(scriptManager));
-    }
-
-    private void register(String[] commandNames, Command command) {
-        for (String commandName : commandNames) {
-            commandMap.put(commandName, command);
-        }
-    }
 }

--- a/shell/src/main/java/com/samsung/command/CommandRegistry.java
+++ b/shell/src/main/java/com/samsung/command/CommandRegistry.java
@@ -1,0 +1,60 @@
+package com.samsung.command;
+
+import com.samsung.command.testscript.*;
+import com.samsung.command.testshell.*;
+import com.samsung.file.FileManager;
+import com.samsung.file.JarExecutor;
+
+import java.util.Map;
+
+public class CommandRegistry {
+
+    private final Map<String, Command> commandMap;
+
+    public CommandRegistry(Map<String, Command> commandMap) {
+        this.commandMap = commandMap;
+        initShellCommand();
+        initScriptCommand();
+    }
+
+    public Command getCommand(String name) {
+        return commandMap.get(name);
+    }
+
+    private void initShellCommand() {
+        TestShellManager testShellManager = new TestShellManager(new JarExecutor(), FileManager.getInstance());
+        register("write", new WriteCommand(testShellManager));
+        register("read", new ReadCommand(testShellManager));
+        register("erase", new EraseCommand(testShellManager));
+        register("erase_range", new EraseRangeCommand(testShellManager));
+        register("exit", new ExitCommand(testShellManager));
+        register("help", new HelpCommand(testShellManager));
+        register("fullwrite", new FullWriteCommand(testShellManager));
+        register("fullread", new FullReadCommand(testShellManager));
+        register("flush", new FlushCommand(testShellManager));
+    }
+
+    private void initScriptCommand() {
+        ScriptManager scriptManager = new ScriptManager(FileManager.getInstance(), new JarExecutor(), RandomHex.getInstance());
+
+        String[] script1CommandNames = {"1_FullWriteAndReadCompare", "1_"};
+        String[] script2CommandNames = {"2_PartialLBAWrite", "2_"};
+        String[] script3CommandNames = {"3_WriteReadAging", "3_"};
+        String[] script4CommandNames = {"4_EraseAndWriteAging", "4_"};
+
+        register(script1CommandNames, new TestScript1Command(scriptManager));
+        register(script2CommandNames, new TestScript2Command(scriptManager));
+        register(script3CommandNames, new TestScript3Command(scriptManager));
+        register(script4CommandNames, new TestScript4Command(scriptManager));
+    }
+
+    private void register(String name, Command command) {
+        commandMap.put(name, command);
+    }
+
+    private void register(String[] names, Command command) {
+        for (String name : names) {
+            register(name, command);
+        }
+    }
+}

--- a/shell/src/main/java/com/samsung/handler/factory/CommandHandlerFactory.java
+++ b/shell/src/main/java/com/samsung/handler/factory/CommandHandlerFactory.java
@@ -1,6 +1,7 @@
 package com.samsung.handler.factory;
 
 import com.samsung.command.CommandInvoker;
+import com.samsung.command.CommandRegistry;
 import com.samsung.handler.CommandHandler;
 import com.samsung.handler.impl.FileCommandHandler;
 import com.samsung.handler.impl.InteractiveCommandHandler;
@@ -10,14 +11,18 @@ import java.util.HashMap;
 public class CommandHandlerFactory {
 
     public static CommandHandler getCommandHandler(String[] args) {
-        CommandInvoker invoker = new CommandInvoker(new HashMap<>());
-
-        if (hasArguments(args)) return new FileCommandHandler(invoker);
-        return new InteractiveCommandHandler(invoker);
+        if (hasArguments(args)){
+            return new FileCommandHandler(createCommandInvoker());
+        }
+        return new InteractiveCommandHandler(createCommandInvoker());
     }
 
     private static boolean hasArguments(String[] mainArgs) {
         return mainArgs.length != 0;
+    }
+
+    private static CommandInvoker createCommandInvoker() {
+        return new CommandInvoker(new CommandRegistry(new HashMap<>()));
     }
 
 }

--- a/shell/src/test/java/com/samsung/command/CommandInvokerTest.java
+++ b/shell/src/test/java/com/samsung/command/CommandInvokerTest.java
@@ -1,102 +1,44 @@
 package com.samsung.command;
 
-import com.samsung.command.testscript.TestScript1Command;
-import com.samsung.command.testscript.TestScript2Command;
-import com.samsung.command.testscript.TestScript3Command;
-import com.samsung.command.testscript.TestScript4Command;
-import com.samsung.command.testshell.*;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CommandInvokerTest {
     public static final String VALID_COMMAND_NAME = "help";
     public static final String INVALID_COMMAND_NAME = "abcde";
-    public static final String[] cmdArgs = new String[1];
+    public static final String[] VALID_CMD_ARGS = {VALID_COMMAND_NAME};
+    public static final String[] INVALID_CMD_ARGS = {INVALID_COMMAND_NAME};
 
     @Mock
     private Command mockCommand;
 
-    private Map<String, Command> commandMap;
+    @Mock
+    private CommandRegistry mockRegistry;
+
+    @InjectMocks
     private CommandInvoker invoker;
-
-    @BeforeEach
-    void setUp() {
-        commandMap = new HashMap<>();
-        invoker = new CommandInvoker(commandMap);
-    }
-
-    @DisplayName("명령어 초기화 검증 테스트 - @BeforeEach에서 생성자 호출 시 명령어 초기화 됨")
-    @Test
-    void initTest() {
-        assertShellComands();
-        assertScriptCommands();
-    }
 
     @DisplayName("ShellCommand exectue 메서드 실행 pass 테스트")
     @Test
     void execute_pass_test() {
-        commandMap.put(VALID_COMMAND_NAME, mockCommand);
-        cmdArgs[0] = VALID_COMMAND_NAME;
+        doReturn(mockCommand).when(mockRegistry).getCommand(VALID_COMMAND_NAME);
 
-        invoker.execute(cmdArgs);
+        invoker.execute(VALID_CMD_ARGS);
 
-        verify(mockCommand, times(1)).execute(cmdArgs);
+        verify(mockRegistry, times(1)).getCommand(VALID_COMMAND_NAME);
     }
 
     @DisplayName("ShellCommand exectue 메서드 실행 예외 테스트")
     @Test
     void execute_exception_test() {
-        cmdArgs[0] = INVALID_COMMAND_NAME;
-
-        assertThrows(RuntimeException.class, () -> invoker.execute(cmdArgs));
-    }
-
-    private void assertShellComands() {
-        assertThat(commandMap.get("write")).isInstanceOf(WriteCommand.class);
-        assertThat(commandMap.get("read")).isInstanceOf(ReadCommand.class);
-        assertThat(commandMap.get("exit")).isInstanceOf(ExitCommand.class);
-        assertThat(commandMap.get("help")).isInstanceOf(HelpCommand.class);
-        assertThat(commandMap.get("fullwrite")).isInstanceOf(FullWriteCommand.class);
-        assertThat(commandMap.get("fullread")).isInstanceOf(FullReadCommand.class);
-    }
-
-    private void assertScriptCommands() {
-        assertTestScript1Commands();
-        assertTestScript2Commands();
-        assertTestScript3Commands();
-        assertTestScript4Commands();
-    }
-
-    private void assertTestScript1Commands() {
-        assertThat(commandMap.get("1_FullWriteAndReadCompare")).isInstanceOf(TestScript1Command.class);
-        assertThat(commandMap.get("1_")).isInstanceOf(TestScript1Command.class);
-    }
-
-    private void assertTestScript2Commands() {
-        assertThat(commandMap.get("2_PartialLBAWrite")).isInstanceOf(TestScript2Command.class);
-        assertThat(commandMap.get("2_")).isInstanceOf(TestScript2Command.class);
-    }
-
-    private void assertTestScript3Commands() {
-        assertThat(commandMap.get("3_WriteReadAging")).isInstanceOf(TestScript3Command.class);
-        assertThat(commandMap.get("3_")).isInstanceOf(TestScript3Command.class);
-    }
-
-    private void assertTestScript4Commands() {
-        assertThat(commandMap.get("4_EraseAndWriteAging")).isInstanceOf(TestScript4Command.class);
-        assertThat(commandMap.get("4_")).isInstanceOf(TestScript4Command.class);
+        assertThrows(RuntimeException.class, () -> invoker.execute(INVALID_CMD_ARGS));
     }
 }

--- a/shell/src/test/java/com/samsung/command/CommandRegistryTest.java
+++ b/shell/src/test/java/com/samsung/command/CommandRegistryTest.java
@@ -1,0 +1,76 @@
+package com.samsung.command;
+
+import com.samsung.command.testscript.TestScript1Command;
+import com.samsung.command.testscript.TestScript2Command;
+import com.samsung.command.testscript.TestScript3Command;
+import com.samsung.command.testscript.TestScript4Command;
+import com.samsung.command.testshell.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommandRegistryTest {
+
+    private Map<String, Command> commandMap;
+    private CommandRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        commandMap = new HashMap<>();
+        registry = new CommandRegistry(commandMap);
+    }
+
+    @DisplayName("명령어 초기화 검증 테스트 - @BeforeEach에서 생성자 호출 시 명령어 Map 초기화 됨")
+    @Test
+    void initTest() {
+        assertShellComands();
+        assertScriptCommands();
+    }
+
+    @DisplayName("getCommand 메서드 실행 테스트  - @BeforeEach에서 생성자 호출 시 명령어 Map 초기화 됨")
+    @Test
+    void getCommandTest() {
+        assertThat(registry.getCommand("write")).isInstanceOf(WriteCommand.class);
+    }
+
+    private void assertShellComands() {
+        assertThat(commandMap.get("write")).isInstanceOf(WriteCommand.class);
+        assertThat(commandMap.get("read")).isInstanceOf(ReadCommand.class);
+        assertThat(commandMap.get("exit")).isInstanceOf(ExitCommand.class);
+        assertThat(commandMap.get("help")).isInstanceOf(HelpCommand.class);
+        assertThat(commandMap.get("fullwrite")).isInstanceOf(FullWriteCommand.class);
+        assertThat(commandMap.get("fullread")).isInstanceOf(FullReadCommand.class);
+    }
+
+    private void assertScriptCommands() {
+        assertTestScript1Commands();
+        assertTestScript2Commands();
+        assertTestScript3Commands();
+        assertTestScript4Commands();
+    }
+
+    private void assertTestScript1Commands() {
+        assertThat(commandMap.get("1_FullWriteAndReadCompare")).isInstanceOf(TestScript1Command.class);
+        assertThat(commandMap.get("1_")).isInstanceOf(TestScript1Command.class);
+    }
+
+    private void assertTestScript2Commands() {
+        assertThat(commandMap.get("2_PartialLBAWrite")).isInstanceOf(TestScript2Command.class);
+        assertThat(commandMap.get("2_")).isInstanceOf(TestScript2Command.class);
+    }
+
+    private void assertTestScript3Commands() {
+        assertThat(commandMap.get("3_WriteReadAging")).isInstanceOf(TestScript3Command.class);
+        assertThat(commandMap.get("3_")).isInstanceOf(TestScript3Command.class);
+    }
+
+    private void assertTestScript4Commands() {
+        assertThat(commandMap.get("4_EraseAndWriteAging")).isInstanceOf(TestScript4Command.class);
+        assertThat(commandMap.get("4_")).isInstanceOf(TestScript4Command.class);
+    }
+}


### PR DESCRIPTION
## 개발 내용
- CommandInvoker가 명령어 등록, 초기화 등의 역할을 과하게 맡고 있어서 해당 책임을 분리하였음.
- SRP 원칙에 근거하여 CommandRegistry 클래스를 추가로 만들어 해당 책임을 분리 시킴.

## 테스트 결과
![image](https://github.com/user-attachments/assets/b19447a4-303a-46ae-94df-37ce121cc6d5)